### PR TITLE
Fix: Resolve Namespace issue

### DIFF
--- a/Generators/TypeScript/TypeScriptDefinitionBuilder.cs
+++ b/Generators/TypeScript/TypeScriptDefinitionBuilder.cs
@@ -49,7 +49,8 @@ public class TypeScriptDefinitionBuilder : IDefinitionBuilder<TypeScriptCompiler
         {
             IOptionalPropertyType => new NoPropertyValue(),
             AnyType or ObjectType => new SomePropertyValue("{} as any"),
-            ListType or MapType or SetType => new SomePropertyValue("[]"),
+            ListType or SetType => new SomePropertyValue("[]"),
+            MapType => new SomePropertyValue("{}"),
             StringType => new SomePropertyValue("''"),
             _ => new NoPropertyValue()
         };
@@ -80,7 +81,11 @@ public class TypeScriptDefinitionBuilder : IDefinitionBuilder<TypeScriptCompiler
                 sb.Append(']');
                 return new SomePropertyValue(sb.ToString());
             case EnumValue enumValue:
+                // Ensure enum references use simple identifier (no namespaces)
                 string enumPrefix = Compiler.GetCompiledPropertyType(enumValue.Type).Name;
+                int lastDotIdx = enumPrefix.LastIndexOf('.');
+                if (lastDotIdx >= 0 && lastDotIdx < enumPrefix.Length - 1)
+                    enumPrefix = enumPrefix[(lastDotIdx + 1)..];
                 string value = string.Join(" | ", enumValue.Values.Select(x => $"{enumPrefix}.{x}"));
                 return new SomePropertyValue(value);
             case MapValue:


### PR DESCRIPTION
This pull request significantly improves TypeScript code generation by adding automatic import statements for user-defined types referenced across files and refining type handling for property and enum references. The main changes include generating correct import statements, ensuring type names are simplified for TypeScript, and fixing default value generation for map types.

### TypeScript Import Generation

* Added logic to automatically generate and insert `import` statements for user-defined types referenced from other files, ensuring proper symbol resolution and avoiding self-imports (`TypeScriptCompiler.cs`). [[1]](diffhunk://#diff-40f4885184e0f6aebef8df9d9b35e0f2f4ed188dc47ec7d7532918913231e3c5R25-R35) [[2]](diffhunk://#diff-40f4885184e0f6aebef8df9d9b35e0f2f4ed188dc47ec7d7532918913231e3c5R247-R340)

### Type Name Handling

* Updated property type compilation to emit only the simple identifier (without namespaces or optional markers) for user-defined types, aligning with TypeScript conventions (`TypeScriptCompiler.cs`).
* Ensured enum value references use the simple (unqualified) identifier for enum types in generated code (`TypeScriptDefinitionBuilder.cs`).

### Default Value Generation

* Corrected default value generation for map types to use `{}` instead of `[]` in TypeScript, matching expected type shapes (`TypeScriptDefinitionBuilder.cs`).…ined types, simplify type names in property definitions, and ensure enum references use simple identifiers.